### PR TITLE
buildah: switch to v1beta1

### DIFF
--- a/tasks/buildah/0.6/buildah.yaml
+++ b/tasks/buildah/0.6/buildah.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1
+apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: buildah


### PR DESCRIPTION
- Works with more tekton version
- ArtifactHub doesn't support `v1` today

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>
