### PR TITLE
[WIP] add RHACS tasks

### DIFF
--- a/tasks/rhacs-deployment-check/3.73/README.md
+++ b/tasks/rhacs-deployment-check/3.73/README.md
@@ -1,0 +1,72 @@
+# Red Hat Advanced Cluster Security Deployment Check Task
+
+Check a deployment manifest against RHACS deploy lifecycle policies to validate a pipeline run using `roxctl`.
+
+## Prerequisites
+
+This task requires an active installation of [Red Hat Advanced Cluster Security (RHACS)](https://www.redhat.com/en/resources/advanced-cluster-security-for-kubernetes-datasheet).  It also requires configuration of secrets for the Central endpoint and an API token with at least CI privileges.
+
+<https://www.redhat.com/en/technologies/cloud-computing/openshift/advanced-cluster-security-kubernetes>
+
+## Install the Task
+
+```bash
+kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/rhacs-deployment-check/3.73/raw
+```
+
+## Parameters
+
+- **`deployment`**: Filename of deployment manifest. May be relative to workspace root or fully qualified. (example -- kustomize/overlays/dev/deployment.yaml)
+- **`insecure-skip-tls-verify`**: Skip verification the TLS certs of the Central endpoint and registry. Examples: _"true", **"false"**_.
+- **`output_format`**:  Examples: _**table**, csv, json, junit_
+- **`rox_central_endpoint`**: Secret containing the address:port tuple for StackRox Central. Default: _**rox-central-endpoint**_
+- **`rox_api_token`**: Secret containing the StackRox API token with CI permissions. Default: _**rox-api-token**_
+## Workspaces
+
+- **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md) containing the deployment manifest.
+
+## Usage
+
+Create secrets for authentication to RHACS Central endpoint and supply filesystem path to deployment manifest for checking.
+
+Run this task after rhacs-image-scan to ensure most up to date CVE data for images referenced by the deployment.
+
+If the deployment violates one or more enforced policies, this task will return a failure and cause the pipeline run to fail. 
+
+**Example secret creation:**
+
+```bash
+kubectl create secret generic rox-api-token \
+  --from-literal=rox_api_token="$ROX_API_TOKEN"
+kubectl create secret generic rox-central-endpoint \
+  --from-literal=rox_central_endpoint=central.stackrox.svc:443
+```
+
+**Example task use:**
+
+```yaml
+  tasks:
+    - name: check-deployment
+    taskRef:
+      name: rhacs-deployment-check
+      kind: Task
+    workspaces:
+    - name: source
+      workspace: shared-workspace
+    params:
+    - name: deployment
+      value: $(params.deployment)
+    runAfter:
+    - fetch-repository
+```
+
+**Samples:**
+
+* [secrets.yaml](samples/secrets.yaml) example secret
+* [pipeline.yaml](samples/pipeline.yaml) demonstrates use in a pipeline.
+* [pipelinerun.yaml](samples/pipelinerun.yaml) demonstrates use in a pipelinerun.
+
+# Known Issues
+
+* Skipping TLS Verify is currently required. TLS trust bundle not working for quay.io etc.
+* If the namespace value is not found in the deployment manifest any RHACS policies which are scoped to specific namespaces will not be matched.

--- a/tasks/rhacs-deployment-check/3.73/rhacs-deployment-check.yaml
+++ b/tasks/rhacs-deployment-check/3.73/rhacs-deployment-check.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: rhacs-deployment-check
+  labels:
+    app.kubernetes.io/version: "3.73"
+  annotations:
+    tekton.dev/tags: security
+    tekton.dev/categories: Security
+    tekton.dev/displayName: "Policy check a deployment with Red Hat Advanced Cluster Security"
+    tekton.dev/platforms: "linux/amd64"
+    tekton.dev/pipelines.minVersion: "0.18.0"
+spec:
+  description: >-
+    Policy check a deployment with Red Hat Advanced Cluster Security.
+
+    This tasks allows you to check a Kubernetes deployment manifest against policies
+    and apply enforcement to fail pipelines.
+  params:
+    - name: rox_central_endpoint
+      type: string
+      description: Name of secret containing the address:port tuple for RHACS Stackrox Central.
+      default: rox-central-endpoint
+    - name: rox_api_token
+      type: string
+      description: Name of secret containing the RHACS StackRox API token with CI permissions.
+      default: rox-api-token
+    - name: rox_image
+      description: Image providing the roxctl tool.
+      default: quay.io/stackrox-io/roxctl:3.73.0
+    - name: deployment
+      type: string
+      description: |
+        Deployment filename to check.
+        Examples: 'deployment.yaml', '$(workspaces.source.path)/base/deployment.yaml'
+      default: '$(workspaces.source.path)/deployment.yaml'
+    - name: output_format
+      description: Results output format (csv | json | junit | table)
+      type: string
+      default: "table"
+    - name: insecure-skip-tls-verify
+      type: string
+      description: |
+        Do not verify TLS certificates.
+
+        When set to "true", skip verifying the TLS certs of the Central endpoint and registry.
+      default: "false"
+  workspaces:
+    - name: source
+  results:
+    - name: check_output
+      description: Output of `roxctl deployment check`
+  steps:
+    - name: rox-deploy-check
+      image: $(params.rox_image)
+      workingDir: $(workspaces.source.path)
+      env:
+        - name: DEPLOYMENT
+          value: $(params.deployment)
+        - name: HOME
+          value: /tekton/home
+        - name: INSECURE
+          value: $(params.insecure-skip-tls-verify)
+        - name: OUTPUT
+          value: $(params.output_format)
+        - name: ROX_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: $(params.rox_api_token)
+              key: rox_api_token
+        - name: ROX_CENTRAL_ENDPOINT
+          valueFrom:
+            secretKeyRef:
+              name: $(params.rox_central_endpoint)
+              key: rox_central_endpoint
+      args:
+        - deployment
+        - check
+        - --endpoint=$(ROX_CENTRAL_ENDPOINT)
+        - --insecure-skip-tls-verify=$(INSECURE)
+        - --output=$(OUTPUT)
+        - --file=$(DEPLOYMENT)

--- a/tasks/rhacs-deployment-check/3.73/samples/pipeline.yaml
+++ b/tasks/rhacs-deployment-check/3.73/samples/pipeline.yaml
@@ -1,0 +1,100 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: rox-pipeline
+spec:
+
+  workspaces:
+    - name: shared-workspace
+
+  params:
+    - name: deployment-name
+      type: string
+      description: name of the deployment resource to be patched
+    - name: deployment
+      type: string
+      description: filename of the deployment to be patched
+    - name: git-url
+      type: string
+      description: url of the git repo for the code of deployment
+    - name: git-revision
+      type: string
+      description: revision to be used from repo of the code for deployment
+      default: main
+    - name: IMAGE
+      type: string
+      description: image to be build from the code
+
+  tasks:
+    # checkout source code
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+        kind: ClusterTask
+      workspaces:
+      - name: output
+        workspace: shared-workspace
+      params:
+      - name: url
+        value: $(params.git-url)
+      - name: subdirectory
+        value: ""
+      - name: deleteExisting
+        value: "true"
+      - name: revision
+        value: $(params.git-revision)
+
+    # validate deployment against defined  RHACS policies
+    - name: police-deployment
+      taskRef:
+        name: rhacs-deployment-check
+        kind: Task
+      workspaces:
+      - name: source
+        workspace: shared-workspace
+      params:
+      - name: deployment
+        value: $(params.deployment)
+      - name: insecure-skip-tls-verify
+        value: "true"
+      runAfter:
+      - fetch-repository
+
+    - name: build-image
+      taskRef:
+        name: buildah
+        kind: ClusterTask
+      params:
+      - name: IMAGE
+        value: $(params.IMAGE)
+      workspaces:
+      - name: source
+        workspace: shared-workspace
+      runAfter:
+      - fetch-repository
+
+    # scan image for vulns using RHACS
+    - name: scan-image
+      taskRef:
+        name: rhacs-image-scan
+        kind: Task
+      params:
+      - name: image
+        value: "$(params.IMAGE)@$(tasks.build-image.results.IMAGE_DIGEST)"
+      - name: insecure-skip-tls-verify
+        value: "true" # stackrox to OCP image registry x509 fail...
+      runAfter:
+      - build-image
+
+    # validate image against RHACS policies
+    - name: police-image
+      taskRef:
+        name: rhacs-image-check
+        kind: Task
+      params:
+      - name: image
+        value: "$(params.IMAGE)@$(tasks.build-image.results.IMAGE_DIGEST)"
+      - name: insecure-skip-tls-verify
+        value: "true"
+      runAfter:
+      - scan-image

--- a/tasks/rhacs-deployment-check/3.73/samples/pipelinerun.yaml
+++ b/tasks/rhacs-deployment-check/3.73/samples/pipelinerun.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: rox-pipelinerun
+spec:
+  pipelineRef:
+    name: rox-pipeline
+  params:
+  - name: deployment-name
+    value: pipelines-vote-api
+  - name: deployment
+    value: k8s/deployment.yaml
+  - name: git-url
+    value: https://github.com/openshift/pipelines-vote-api.git
+  - name: git-revision
+    value: pipelines-1.7
+  - name: IMAGE
+    value: image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/pipelines-vote-ui
+  - name: insecure-skip-tls-verify
+    value: "true"
+  workspaces:
+  - name: shared-workspace
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 500Mi

--- a/tasks/rhacs-deployment-check/3.73/samples/secrets.yaml
+++ b/tasks/rhacs-deployment-check/3.73/samples/secrets.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: rox-api-token
+data:
+  rox_api_token: EXAMPLE
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+data:
+  rox_central_endpoint: Y2VudHJhbC5zdGFja3JveC5zdmM6NDQz
+metadata:
+  name: rox-central-endpoint

--- a/tasks/rhacs-deployment-check/OWNERS
+++ b/tasks/rhacs-deployment-check/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- dlbewley
+reviewers:
+- dlbewley

--- a/tasks/rhacs-image-check/3.73/README.md
+++ b/tasks/rhacs-image-check/3.73/README.md
@@ -1,0 +1,63 @@
+# Red Hat Advanced Cluster Security Image Check Task
+
+Check an image against RHACS build and deploy lifecycle policies to validate a pipeline run using `roxctl`.
+
+It's a companion to the rhacs-image-scan task, which returns full vulnerability scan results for an image.
+
+## Prerequisites
+
+This task requires an active installation of [Red Hat Advanced Cluster Security (RHACS)](https://www.redhat.com/en/resources/advanced-cluster-security-for-kubernetes-datasheet).  It also requires configuration of secrets for the Central endpoint and an API token with at least CI privileges.
+
+## Install the Task
+
+```bash
+kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/rhacs-image-check/3.73/raw
+```
+
+## Parameters
+
+- **`image`**: Full name of image to scan. Examples: _gcr.io/rox/sample:5.0-rc1, **$(params.IMAGE)**, $(params.IMAGE)@$(tasks.buildah.results.IMAGE_DIGEST)_
+- **`insecure-skip-tls-verify`**: Skip verification the TLS certs for Central endpoint and registry. Examples: _"true", **"false"**_.
+- **`output_format`**:  Examples: _**table**, csv, json, junit_
+- **`rox_central_endpoint`**: Secret containing the address:port tuple for StackRox Central. Default: _**rox-central-endpoint**_
+- **`rox_api_token`**: Secret containing the StackRox API token with CI permissions. Default: _**rox-api-token**_
+
+## Usage
+
+Checks images that have been pushed to a registry.  This enables scanning regardless of whether the build is using traditional Docker-based approaches, hosted/SaaS-based approaches where the Docker socket may not be directly available, or rootless approaches like `kaniko` and `buildah`.
+
+If the image violates one or more enforced policies, this task will return a failure and cause the pipeline run to fail.
+
+**Example secret creation:**
+
+```bash
+kubectl create secret generic rox-api-token \
+  --from-literal=rox_api_token="$ROX_API_TOKEN"
+kubectl create secret generic rox-central-endpoint \
+  --from-literal=rox_central_endpoint=central.stackrox.svc:443
+```
+
+**Example task use:**
+
+```yaml
+  tasks:
+    - name: image-check
+      taskRef:
+        name: rhacs-image-check
+        kind: Task
+      params:
+        - name: image
+          value: "$(params.IMAGE)@$(tasks.build-image.results.IMAGE_DIGEST)"
+      runAfter:
+      - image-scan
+```
+
+**Samples:**
+
+- [secrets.yaml](samples/secrets.yaml) example secret
+- [pipeline.yaml](samples/pipeline.yaml) demonstrates use in a pipeline.
+- [pipelinerun.yaml](samples/pipelinerun.yaml) demonstrates use in a pipelinerun.
+
+# Known Issues
+
+* Skipping TLS Verify is currently required. TLS trust bundle not working for quay.io etc.

--- a/tasks/rhacs-image-check/3.73/rhacs-image-check.yaml
+++ b/tasks/rhacs-image-check/3.73/rhacs-image-check.yaml
@@ -1,0 +1,82 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: rhacs-image-check
+  labels:
+    app.kubernetes.io/version: "3.73"
+  annotations:
+    tekton.dev/tags: security
+    tekton.dev/categories: Security
+    tekton.dev/displayName: "Policy check an image with Red Hat Advanced Cluster Security"
+    tekton.dev/platforms: "linux/amd64"
+    tekton.dev/pipelines.minVersion: "0.18.0"
+spec:
+  description: >-
+    Policy check an image with Red Hat Advanced Cluster Security.
+
+    This tasks allows you to check an image against build-time policies
+    and apply enforcement to fail builds.  It's a companion to the
+    rhacs-image-scan task, which returns full vulnerability scan
+    results for an image.
+  params:
+    - name: rox_central_endpoint
+      type: string
+      description: Name of secret containing the address:port tuple for RHACS Stackrox Central.
+      default: rox-central-endpoint
+    - name: rox_api_token
+      type: string
+      description: Name of secret containing the RHACS StackRox API token with CI permissions.
+      default: rox-api-token
+    - name: rox_image
+      description: Image providing the roxctl tool.
+      default: quay.io/stackrox-io/roxctl:3.73.0
+    - name: image
+      type: string
+      description: |
+        Full name of image to check.
+        Examples: 'gcr.io/rox/sample:5.0-rc1', '$(params.IMAGE)', '$(params.IMAGE)@$(tasks.buildah.results.IMAGE_DIGEST)'
+      default: '$(params.IMAGE)'
+    - name: output_format
+      description: Results output format (csv | json | junit | table)
+      type: string
+      default: "table"
+    - name: insecure-skip-tls-verify
+      type: string
+      description: |
+        Do not verify TLS certificates.
+
+        When set to "true", skip verifying the TLS certs of the Central endpoint and registry.
+      default: "false"
+  results:
+    - name: check_output
+      description: Output of `roxctl image check`
+  steps:
+    - name: rox-image-check
+      image: $(params.rox_image)
+      env:
+        - name: HOME
+          value: /tekton/home
+        - name: IMAGE
+          value: $(params.image)
+        - name: INSECURE
+          value: $(params.insecure-skip-tls-verify)
+        - name: OUTPUT
+          value: $(params.output_format)
+        - name: ROX_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: $(params.rox_api_token)
+              key: rox_api_token
+        - name: ROX_CENTRAL_ENDPOINT
+          valueFrom:
+            secretKeyRef:
+              name: $(params.rox_central_endpoint)
+              key: rox_central_endpoint
+      args:
+        - image
+        - check
+        - --endpoint=$(ROX_CENTRAL_ENDPOINT)
+        - --insecure-skip-tls-verify=$(INSECURE)
+        - --output=$(OUTPUT)
+        - --image=$(IMAGE)

--- a/tasks/rhacs-image-check/3.73/samples/pipeline.yaml
+++ b/tasks/rhacs-image-check/3.73/samples/pipeline.yaml
@@ -1,0 +1,100 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: rox-pipeline
+spec:
+
+  workspaces:
+    - name: shared-workspace
+
+  params:
+    - name: deployment-name
+      type: string
+      description: name of the deployment resource to be patched
+    - name: deployment
+      type: string
+      description: filename of the deployment to be patched
+    - name: git-url
+      type: string
+      description: url of the git repo for the code of deployment
+    - name: git-revision
+      type: string
+      description: revision to be used from repo of the code for deployment
+      default: main
+    - name: IMAGE
+      type: string
+      description: image to be build from the code
+
+  tasks:
+    # checkout source code
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+        kind: ClusterTask
+      workspaces:
+      - name: output
+        workspace: shared-workspace
+      params:
+      - name: url
+        value: $(params.git-url)
+      - name: subdirectory
+        value: ""
+      - name: deleteExisting
+        value: "true"
+      - name: revision
+        value: $(params.git-revision)
+
+    # validate deployment against defined  RHACS policies
+    - name: police-deployment
+      taskRef:
+        name: rhacs-deployment-check
+        kind: Task
+      workspaces:
+      - name: source
+        workspace: shared-workspace
+      params:
+      - name: deployment
+        value: $(params.deployment)
+      - name: insecure-skip-tls-verify
+        value: "true"
+      runAfter:
+      - fetch-repository
+
+    - name: build-image
+      taskRef:
+        name: buildah
+        kind: ClusterTask
+      params:
+      - name: IMAGE
+        value: $(params.IMAGE)
+      workspaces:
+      - name: source
+        workspace: shared-workspace
+      runAfter:
+      - fetch-repository
+
+    # scan image for vulns using RHACS
+    - name: scan-image
+      taskRef:
+        name: rhacs-image-scan
+        kind: Task
+      params:
+      - name: image
+        value: "$(params.IMAGE)@$(tasks.build-image.results.IMAGE_DIGEST)"
+      - name: insecure-skip-tls-verify
+        value: "true" # stackrox to OCP image registry x509 fail...
+      runAfter:
+      - build-image
+
+    # validate image against RHACS policies
+    - name: police-image
+      taskRef:
+        name: rhacs-image-check
+        kind: Task
+      params:
+      - name: image
+        value: "$(params.IMAGE)@$(tasks.build-image.results.IMAGE_DIGEST)"
+      - name: insecure-skip-tls-verify
+        value: "true"
+      runAfter:
+      - scan-image

--- a/tasks/rhacs-image-check/3.73/samples/pipelinerun.yaml
+++ b/tasks/rhacs-image-check/3.73/samples/pipelinerun.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: rox-pipelinerun
+spec:
+  pipelineRef:
+    name: rox-pipeline
+  params:
+  - name: deployment-name
+    value: pipelines-vote-api
+  - name: deployment
+    value: k8s/deployment.yaml
+  - name: git-url
+    value: https://github.com/openshift/pipelines-vote-api.git
+  - name: git-revision
+    value: pipelines-1.7
+  - name: IMAGE
+    value: image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/pipelines-vote-ui
+  - name: insecure-skip-tls-verify
+    value: "true"
+  workspaces:
+  - name: shared-workspace
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 500Mi

--- a/tasks/rhacs-image-check/3.73/samples/rox-secrets.yaml
+++ b/tasks/rhacs-image-check/3.73/samples/rox-secrets.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+stringData:
+  rox_central_endpoint: "{{ central_addr }}:{{ central_port }}"
+  # The address:port tuple for StackRox Central (example - central.stackrox.svc:443)
+  # This must include the port number
+  rox_api_token: "{{ rox_api_token }}"
+  # StackRox API token with CI permissions
+  # Refer to below
+  # https://help.stackrox.com/docs/use-the-api/#generate-an-access-token
+kind: Secret
+metadata:
+  name: roxsecrets
+  namespace: pipeline-demo
+type: Opaque

--- a/tasks/rhacs-image-check/3.73/samples/secrets.yaml
+++ b/tasks/rhacs-image-check/3.73/samples/secrets.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: rox-api-token
+data:
+  rox_api_token: EXAMPLE
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+data:
+  rox_central_endpoint: Y2VudHJhbC5zdGFja3JveC5zdmM6NDQz
+metadata:
+  name: rox-central-endpoint

--- a/tasks/rhacs-image-check/OWNERS
+++ b/tasks/rhacs-image-check/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- dlbewley
+reviewers:
+- dlbewley

--- a/tasks/rhacs-image-scan/3.73/README.md
+++ b/tasks/rhacs-image-scan/3.73/README.md
@@ -1,0 +1,72 @@
+# Red Hat Advanced Cluster Security Image Scan Task
+
+Scan an image for vulnerabilities and metadata against RHACS build and deploy lifecycle policies to validate a pipeline run using `roxctl`.
+
+This tasks allows you to return full vulnerability scan results for an image in JSON, CSV, or Pretty format.  It's a companion to the rhacs-image-check task.
+
+## Prerequisites
+
+This task requires an active installation of [Red Hat Advanced Cluster Security (RHACS)](https://www.redhat.com/en/resources/advanced-cluster-security-for-kubernetes-datasheet) or [StackRox](https://www.stackrox.io/).  It also requires configuration of secrets for the Central endpoint and an API token with at least CI privileges.
+
+## Install the Task
+
+```bash
+kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/rhacs-image-scan/3.73/raw
+```
+
+## Parameters
+
+- **`image`**: Full name of image to scan. Examples: _gcr.io/rox/sample:5.0-rc1, **$(params.IMAGE)**, $(params.IMAGE)@$(tasks.buildah.results.IMAGE_DIGEST)_
+- **`insecure-skip-tls-verify`**: Skip verification the TLS certs for Central endpoint and registry. Examples: _"true", **"false"**_.
+- **`output_format`**:  Examples: _**json**, csv, pretty_
+- **`rox_central_endpoint`**: Secret containing the address:port tuple for StackRox Central. Default: _**rox-central-endpoint**_
+- **`rox_api_token`**: Secret containing the StackRox API token with CI permissions. Default: _**rox-api-token**_
+
+## Usage
+
+Scans images that have been pushed to a registry.  This enables scanning regardless of whether the build is using traditional Docker-based approaches, hosted/SaaS-based approaches where the Docker socket may not be directly available, or rootless approaches like `kaniko` and `buildah`.
+
+If the image violates one or more enforced policies, this task will return a failure and cause the pipeline run to fail.
+
+**Example secret creation:**
+
+```bash
+kubectl create secret generic rox-api-token \
+  --from-literal=rox_api_token="$ROX_API_TOKEN"
+kubectl create secret generic rox-central-endpoint \
+  --from-literal=rox_central_endpoint=central.stackrox.svc:443
+```
+
+**Example task use:**
+
+```yaml
+  tasks:
+    - name: image-scan
+      taskRef:
+        name: rhacs-image-scan
+        kind: Task
+        params:
+          - name: image
+            value: "$(params.IMAGE)@$(tasks.build-image.results.IMAGE_DIGEST)"
+      runAfter:
+      - build-image
+```
+
+**Samples:**
+
+- [secrets.yaml](samples/secrets.yaml) example secret
+- [pipeline.yaml](samples/pipeline.yaml) demonstrates use in a pipeline.
+- [pipelinerun.yaml](samples/pipelinerun.yaml) demonstrates use in a pipelinerun.
+
+# Known Issues
+
+* Skipping TLS Verify is currently required. TLS trust bundle not working for quay.io etc.
+* Saving scan output as a 'result' does not work, because it is often larger than 4KB. This also would require container invocation via script.
+
+  ```
+  STEP-ROX-IMAGE-SCAN
+
+  {"level":"fatal","ts":1659318163.069173,"caller":"entrypoint/entrypointer.go:188","msg":"Error while handling results: Termination message is above max allowed size 4096, caused by large task result.","stacktrace":"github.com/tektoncd/pipeline/pkg/entrypoint.Entrypointer.Go\n\t/opt/app-root/src/go/src/github.com/tektoncd/pipeline/pkg/entrypoint/entrypointer.go:188\nmain.main\n\t/opt/app-root/src/go/src/github.com/tektoncd/pipeline/cmd/entrypoint/main.go:154\nruntime.main\n\t/usr/lib/golang/src/runtime/proc.go:225"}
+  ```
+
+* Version of roxctl should maintain compatibility with Central API. Maximum allowable version drift is unknown.

--- a/tasks/rhacs-image-scan/3.73/rhacs-image-scan.yaml
+++ b/tasks/rhacs-image-scan/3.73/rhacs-image-scan.yaml
@@ -1,0 +1,80 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: rhacs-image-scan
+  labels:
+    app.kubernetes.io/version: "3.73"
+  annotations:
+    tekton.dev/tags: security
+    tekton.dev/categories: Security
+    tekton.dev/displayName: "Scan an image for vulnerabilities with Red Hat Advanced Cluster Security"
+    tekton.dev/platforms: "linux/amd64"
+    tekton.dev/pipelines.minVersion: "0.18.0"
+spec:
+  description: >-
+    Scan an image with Red Hat Advanced Cluster Security.
+
+    This task allows you to return full vulnerability scan results for an image
+    in CSV, Table, or JSON formats.
+    The companion rhacs-image-check task checks an image against build-time policies.
+  params:
+    - name: rox_central_endpoint
+      type: string
+      description: Name of secret containing the address:port tuple for RHACS Stackrox Central.
+      default: rox-central-endpoint
+    - name: rox_api_token
+      type: string
+      description: Name of secret containing the RHACS StackRox API token with CI permissions.
+      default: rox-api-token
+    - name: rox_image
+      description: Image providing the roxctl tool.
+      default: quay.io/stackrox-io/roxctl:3.73.0
+    - name: image
+      type: string
+      description: |
+        Full name of image to scan.
+
+        SHA 256 digest may be included to ensure scan of sequental runs with same tag.
+        Examples: 'gcr.io/rox/sample:5.0-rc1', '$(params.IMAGE)', '$(params.IMAGE)@$(tasks.buildah.results.IMAGE_DIGEST)'
+      default: '$(params.IMAGE)'
+    - name: output_format
+      type: string
+      description: Results output format (json | csv | table)
+      default: json
+    - name: insecure-skip-tls-verify
+      type: string
+      description: |
+        Do not verify TLS certificates.
+
+        When set to "true", skip verifying the TLS certs of the Central endpoint and registry.
+      default: "false"
+  steps:
+    - name: rox-image-scan
+      image: $(params.rox_image)
+      env:
+        - name: HOME
+          value: /tekton/home
+        - name: IMAGE
+          value: $(params.image)
+        - name: INSECURE
+          value: $(params.insecure-skip-tls-verify)
+        - name: OUTPUT
+          value: $(params.output_format)
+        - name: ROX_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: $(params.rox_api_token)
+              key: rox_api_token
+        - name: ROX_CENTRAL_ENDPOINT
+          valueFrom:
+            secretKeyRef:
+              name: $(params.rox_central_endpoint)
+              key: rox_central_endpoint
+      args:
+        - image
+        - scan
+        - --endpoint=$(ROX_CENTRAL_ENDPOINT)
+        - --insecure-skip-tls-verify=$(INSECURE)
+        - --output=$(OUTPUT)
+        - --image=$(IMAGE)

--- a/tasks/rhacs-image-scan/3.73/samples/pipeline.yaml
+++ b/tasks/rhacs-image-scan/3.73/samples/pipeline.yaml
@@ -1,0 +1,100 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: rox-pipeline
+spec:
+
+  workspaces:
+    - name: shared-workspace
+
+  params:
+    - name: deployment-name
+      type: string
+      description: name of the deployment resource to be patched
+    - name: deployment
+      type: string
+      description: filename of the deployment to be patched
+    - name: git-url
+      type: string
+      description: url of the git repo for the code of deployment
+    - name: git-revision
+      type: string
+      description: revision to be used from repo of the code for deployment
+      default: main
+    - name: IMAGE
+      type: string
+      description: image to be build from the code
+
+  tasks:
+    # checkout source code
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+        kind: ClusterTask
+      workspaces:
+      - name: output
+        workspace: shared-workspace
+      params:
+      - name: url
+        value: $(params.git-url)
+      - name: subdirectory
+        value: ""
+      - name: deleteExisting
+        value: "true"
+      - name: revision
+        value: $(params.git-revision)
+
+    # validate deployment against defined  RHACS policies
+    - name: police-deployment
+      taskRef:
+        name: rhacs-deployment-check
+        kind: Task
+      workspaces:
+      - name: source
+        workspace: shared-workspace
+      params:
+      - name: deployment
+        value: $(params.deployment)
+      - name: insecure-skip-tls-verify
+        value: "true"
+      runAfter:
+      - fetch-repository
+
+    - name: build-image
+      taskRef:
+        name: buildah
+        kind: ClusterTask
+      params:
+      - name: IMAGE
+        value: $(params.IMAGE)
+      workspaces:
+      - name: source
+        workspace: shared-workspace
+      runAfter:
+      - fetch-repository
+
+    # scan image for vulns using RHACS
+    - name: scan-image
+      taskRef:
+        name: rhacs-image-scan
+        kind: Task
+      params:
+      - name: image
+        value: "$(params.IMAGE)@$(tasks.build-image.results.IMAGE_DIGEST)"
+      - name: insecure-skip-tls-verify
+        value: "true" # stackrox to OCP image registry x509 fail...
+      runAfter:
+      - build-image
+
+    # validate image against RHACS policies
+    - name: police-image
+      taskRef:
+        name: rhacs-image-check
+        kind: Task
+      params:
+      - name: image
+        value: "$(params.IMAGE)@$(tasks.build-image.results.IMAGE_DIGEST)"
+      - name: insecure-skip-tls-verify
+        value: "true"
+      runAfter:
+      - scan-image

--- a/tasks/rhacs-image-scan/3.73/samples/pipelinerun.yaml
+++ b/tasks/rhacs-image-scan/3.73/samples/pipelinerun.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: rox-pipelinerun
+spec:
+  pipelineRef:
+    name: rox-pipeline
+  params:
+  - name: deployment-name
+    value: pipelines-vote-api
+  - name: deployment
+    value: k8s/deployment.yaml
+  - name: git-url
+    value: https://github.com/openshift/pipelines-vote-api.git
+  - name: git-revision
+    value: pipelines-1.7
+  - name: IMAGE
+    value: image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/pipelines-vote-ui
+  - name: insecure-skip-tls-verify
+    value: "true"
+  workspaces:
+  - name: shared-workspace
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 500Mi

--- a/tasks/rhacs-image-scan/3.73/samples/secrets.yaml
+++ b/tasks/rhacs-image-scan/3.73/samples/secrets.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: rox-api-token
+data:
+  rox_api_token: EXAMPLE
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+data:
+  rox_central_endpoint: Y2VudHJhbC5zdGFja3JveC5zdmM6NDQz
+metadata:
+  name: rox-central-endpoint

--- a/tasks/rhacs-image-scan/OWNERS
+++ b/tasks/rhacs-image-scan/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- dlbewley
+reviewers:
+- dlbewley

--- a/tasks/rhacs-networkpolicy-generate/3.73/README.md
+++ b/tasks/rhacs-networkpolicy-generate/3.73/README.md
@@ -1,0 +1,86 @@
+# Red Hat Advanced Cluster Security Generate NetworkPolicy Task
+
+Generate suggested NetworkPolicy artifacts given source Kubernetes manifests using `roxctl`.
+
+See the [RHACS documentation](https://docs.openshift.com/acs/3.73/operating/manage-network-policies.html) for more detail.
+
+**This is a Technology Preview feature**
+Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. For more information about the support scope of Red Hat Technology Preview features, see <https://access.redhat.com/support/offerings/techpreview/>
+
+## Prerequisites
+
+This task requires an active installation of [Red Hat Advanced Cluster Security (RHACS)](https://www.redhat.com/en/resources/advanced-cluster-security-for-kubernetes-datasheet).  It also requires configuration of secrets for the Central endpoint and an API token with at least CI privileges.
+
+<https://www.redhat.com/en/technologies/cloud-computing/openshift/advanced-cluster-security-kubernetes>
+
+## Install the Task
+
+```bash
+kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/rhacs-networkpolicy-generate/3.73/raw
+```
+
+## Parameters
+
+- **`manifests`**: Directory holding deployment manifests. May be relative to workspace root or fully qualified. Examples: _"k8s"_
+- **`insecure-skip-tls-verify`**: Skip verification the TLS certs of the Central endpoint and registry. Examples: _"true", **"false"**_.
+- **`networkpolicy-dir`**: Directory to store generated policies in. Example: _$(workspaces.source.path)/networkpolicies_
+- **`rox_api_token`**: Secret containing the StackRox API token with CI permissions. Default: _**rox-api-token**_
+- **`rox_central_endpoint`**: Secret containing the address:port tuple for StackRox Central. Default: _**rox-central-endpoint**_
+- **`rox_image`**: Container image providing `roxctl`. Examples: _**quay.io/stackrox-io/roxctl:3.73.1**, registry.redhat.io/advanced-cluster-security/rhacs-roxctl-rhel8:3.73_
+
+## Workspaces
+
+- **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md) containing the application manifests.
+
+## Usage
+
+Create secrets for authentication to RHACS Central endpoint and supply filesystem path to deployment manifests for analysis.
+
+Run this task after checking out application manifest source code.
+
+**Example secret creation:**
+
+```bash
+kubectl create secret generic rox-api-token \
+  --from-literal=rox_api_token="$ROX_API_TOKEN"
+kubectl create secret generic rox-central-endpoint \
+  --from-literal=rox_central_endpoint=central.stackrox.svc:443
+```
+
+**Example task use:**
+
+```yaml
+  tasks:
+    - name: generate-networkpolicy
+    taskRef:
+      name: rhacs-networkpolicy-generate
+      kind: Task
+    workspaces:
+      - name: source
+        workspace: shared-workspace
+    params:
+      - name: manifests
+        value: $(workspaces.source.path)/k8s
+      - name: networkpolicy-dir
+        value: '$(workspaces.source.path)/networkpolicy'
+    runAfter:
+      - fetch-repository
+```
+
+**Samples:**
+
+* [secrets.yaml](samples/secrets.yaml) example secret
+* [pipeline.yaml](samples/pipeline.yaml) demonstrates use in a pipeline.
+* [pipelinerun.yaml](samples/pipelinerun.yaml) demonstrates use in a pipelinerun.
+
+# Known Issues
+
+* Skipping TLS Verify is currently required. TLS trust bundle not working for quay.io etc.
+* It is not strictly true that a endpoint and token are required to generate network policies. The generate command acts locally, and does not contact Central. I'm not yet aware if the product could change to require a connection later, so these values are currently required by this task for consistency with related tasks.
+* Even with empty values, `--output-dir` and `--output-file` may not be supplied simultaneously. This task takes the opinion that `--output-dir` is best and eschews other options for now.
+  > _ERROR:    Flags [-d|--output-dir, -f|--output-file] cannot be used together_
+  * **Possible RFE for roxctl:**
+    * Permit both `--output-dir` and `--output-file` flags  to exist simultaneously.
+    * In case of _non-null_ values for both, `exit 1`
+    * In case of _non-null_ values for one, write to that location
+    * In case of _null_ values for both, write to `STDOUT`

--- a/tasks/rhacs-networkpolicy-generate/3.73/rhacs-networkpolicy-generate.yaml
+++ b/tasks/rhacs-networkpolicy-generate/3.73/rhacs-networkpolicy-generate.yaml
@@ -1,0 +1,111 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: rhacs-networkpolicy-generate
+  labels:
+    app.kubernetes.io/version: "3.73"
+  annotations:
+    tekton.dev/tags: security
+    tekton.dev/categories: Security
+    tekton.dev/displayName: "Generate NetworkPolicy manifests with Red Hat Advanced Cluster Security"
+    tekton.dev/platforms: "linux/amd64"
+    tekton.dev/pipelines.minVersion: "0.18.0"
+spec:
+  description: >-
+    Generate NetworkPolicy manifests with Red Hat Advanced Cluster Security.
+
+    This tasks allows you to generate NetworkPolicy manifests from application manifests
+    using a technology preview feature of roxctl.
+    https://github.com/stackrox/stackrox/blob/master/roxctl/generate/README.md
+
+  params:
+    - name: rox_api_token
+      type: string
+      description: Name of secret containing the RHACS StackRox API token with CI permissions.
+      default: rox-api-token
+    - name: rox_central_endpoint
+      type: string
+      description: Name of secret containing the address:port tuple for RHACS Stackrox Central.
+      default: rox-central-endpoint
+    - name: rox_image
+      description: Image providing the roxctl tool.
+      default: quay.io/stackrox-io/roxctl:3.73.1
+    - name: manifests
+      type: string
+      description: |
+        Path to manifests to analyze and generate NetworkPolicies for.
+        Examples: '$(workspaces.source.path)/k8s'
+      default: '$(workspaces.source.path)'
+    - name: networkpolicy-dir
+      type: string
+      description: |
+        Directory to store generated NetworkPolicies in. One policy per file.
+        Examples: '$(workspaces.source.path)/networkpolicy'
+      default: '$(workspaces.source.path)/networkpolicy'
+    - name: insecure-skip-tls-verify
+      type: string
+      description: |
+        Do not verify TLS certificates.
+
+        When set to "true", skip verifying the TLS certs of the Central endpoint and registry.
+      default: "false"
+
+  workspaces:
+    - name: source
+
+  results:
+    - name: networkpolicy_dir
+      description: Location of output from `roxctl generate netpol --output-dir`
+
+  stepTemplate:
+    env:
+      - name: HOME
+        value: /tekton/home
+      - name: NETWORKPOLICY_DIR
+        value: $(params.networkpolicy-dir)
+
+  steps:
+    - name: rox-generate-netpol
+      workingDir: $(workspaces.source.path)
+      image: $(params.rox_image)
+      env:
+        - name: INSECURE
+          value: $(params.insecure-skip-tls-verify)
+        - name: MANIFESTS
+          value: $(params.manifests)
+        - name: ROX_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: $(params.rox_api_token)
+              key: rox_api_token
+        - name: ROX_CENTRAL_ENDPOINT
+          valueFrom:
+            secretKeyRef:
+              name: $(params.rox_central_endpoint)
+              key: rox_central_endpoint
+      command:
+        - /roxctl
+      args:
+        - generate
+        - netpol
+        - --endpoint=$(ROX_CENTRAL_ENDPOINT)
+        - --fail
+        - --insecure-skip-tls-verify=$(INSECURE)
+        - --output-dir=$(NETWORKPOLICY_DIR)
+        - --remove
+        - $(MANIFESTS)
+
+    - name: save-results
+      workingDir: $(workspaces.source.path)
+      image: registry.access.redhat.com/ubi8/ubi-minimal@sha256:e7ac72a1704622c46ca2f21f6d2aac3770b9408fa3add45f9d37008dad8f24ec
+      script: |
+        #!/usr/bin/env bash
+        echo -n "NETWORKPOLICY_DIR="
+        echo "$NETWORKPOLICY_DIR"  | tee "$(results.networkpolicy_dir.path)"
+        echo ''
+
+        for policy in "$NETWORKPOLICY_DIR"/*; do
+          echo '---'
+          cat "$policy"
+        done

--- a/tasks/rhacs-networkpolicy-generate/3.73/samples/pipeline.yaml
+++ b/tasks/rhacs-networkpolicy-generate/3.73/samples/pipeline.yaml
@@ -1,0 +1,60 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: rox-pipeline
+spec:
+  workspaces:
+    - name: shared-workspace
+
+  params:
+    - name: networkpolicy-dir
+      type: string
+      description: directory to hold generated networkpolicies
+      default: '$(workspaces.source.path)/networkpolicy'
+    - name: git-url
+      type: string
+      description: url of the git repo for the code of deployment
+    - name: git-revision
+      type: string
+      description: revision to be used from repo of the code for deployment
+    - name: manifests
+      type: string
+      description: Path to manifests to analyze and generate NetworkPolicies for.
+      default: '$(workspaces.source.path)'
+
+  tasks:
+    # checkout source code
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+        kind: ClusterTask
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+      params:
+        - name: url
+          value: $(params.git-url)
+        - name: subdirectory
+          value: ""
+        - name: deleteExisting
+          value: "true"
+        - name: revision
+          value: $(params.git-revision)
+
+    # generate NetworkPolicies through static analysis
+    - name: generate-networkpolicy
+      taskRef:
+        name: rhacs-networkpolicy-generate
+        kind: Task
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+      params:
+        - name: networkpolicy-dir
+          value: $(params.networkpolicy-dir)
+        - name: manifests
+          value: $(params.manifests)
+        - name: insecure-skip-tls-verify
+          value: "true"
+      runAfter:
+        - fetch-repository

--- a/tasks/rhacs-networkpolicy-generate/3.73/samples/pipelinerun.yaml
+++ b/tasks/rhacs-networkpolicy-generate/3.73/samples/pipelinerun.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: rox-pipelinerun
+spec:
+  pipelineRef:
+    name: rox-pipeline
+
+  params:
+    - name: networkpolicy-dir
+      value: '$(workspaces.source.path)/networkpolicy'
+    - name: git-url
+      value: 'https://github.com/GoogleCloudPlatform/microservices-demo.git'
+    - name: manifests
+      value: 'kubernetes-manifests'
+    - name: git-revision
+      value: main
+    - name: insecure-skip-tls-verify
+      value: "true"
+
+  workspaces:
+    - name: shared-workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 50Mi

--- a/tasks/rhacs-networkpolicy-generate/3.73/samples/secrets.yaml
+++ b/tasks/rhacs-networkpolicy-generate/3.73/samples/secrets.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: rox-api-token
+data:
+  rox_api_token: EXAMPLE
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+data:
+  rox_central_endpoint: Y2VudHJhbC5zdGFja3JveC5zdmM6NDQz
+metadata:
+  name: rox-central-endpoint

--- a/tasks/rhacs-networkpolicy-generate/OWNERS
+++ b/tasks/rhacs-networkpolicy-generate/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- dlbewley
+reviewers:
+- dlbewley


### PR DESCRIPTION
Adds tasks to leverage Red Hat Advanced Cluster Security`roxctl` functionality.

**Tasks**
* `rhacs-deployment-check` - Check Deployments against RHACS policies
* `rhacs-image-scan` - Scan Images using RHACS Scanner
* `rhacs-image-check` - Check scanned images againt RHACS policies
* `rhacs-networkpolicy-generate` - Generate NetworkPolicy from analysis of resource manifests

**WIP**
* [ ] What should the updated installation URL should be in the README? Eg:

```bash
# prior URL
kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/rhacs-deployment-check/3.71/raw
```