### PR TITLE
Some `catalog-cd` release and generate-catalog adjustement

### DIFF
--- a/.github/workflows/generate-catalogs.yaml
+++ b/.github/workflows/generate-catalogs.yaml
@@ -19,7 +19,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          go run ./cmd/catalog-cd generate --config ./experimental/externals.yaml experimental
+          go run ./cmd/catalog-cd generate-catalog --config ./experimental/externals.yaml experimental
       - uses: actions/upload-artifact@v3
         with:
           name: experimental-catalog-artifact
@@ -40,7 +40,7 @@ jobs:
           mkdir -p stable/tasks stable/pipelines
           cp -fR tasks/* stable/tasks
           cp -fR pipelines/* stable/pipelines
-          go run ./cmd/catalog-cd generate --config ./externals.yaml stable
+          go run ./cmd/catalog-cd generate-catalog --config ./externals.yaml stable
       - uses: actions/upload-artifact@v3
         with:
           name: stable-catalog-artifact

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -13,12 +13,13 @@ import (
 	"github.com/openshift-pipelines/tektoncd-catalog/internal/fetcher/config"
 )
 
-func FetchFromExternal(e config.External, client *api.RESTClient) (Catalog, error) {
+func FetchFromExternals(e config.External, client *api.RESTClient) (Catalog, error) {
 	c := Catalog{
 		Tasks:     map[string]Task{},
 		Pipelines: map[string]Pipeline{},
 	}
 	for _, r := range e.Repositories {
+		fmt.Fprintln(os.Stderr, "Fetching", r.Name, "("+r.URL+")")
 		var fetchTask, fetchPipeline bool
 		if r.Types == nil {
 			fetchTask = true

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -1,12 +1,13 @@
 package catalog
 
 import (
+	"archive/tar"
+	"compress/gzip"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/cli/go-gh/v2/pkg/api"
 	"github.com/openshift-pipelines/tektoncd-catalog/internal/fetcher"
@@ -15,25 +16,12 @@ import (
 
 func FetchFromExternals(e config.External, client *api.RESTClient) (Catalog, error) {
 	c := Catalog{
-		Tasks:     map[string]Task{},
-		Pipelines: map[string]Pipeline{},
+		Resources: map[string]Resource{},
 	}
 	for _, r := range e.Repositories {
 		fmt.Fprintln(os.Stderr, "Fetching", r.Name, "("+r.URL+")")
-		var fetchTask, fetchPipeline bool
-		if r.Types == nil {
-			fetchTask = true
-			fetchPipeline = true
-		} else {
-			for _, t := range r.Types {
-				if t == "tasks" {
-					fetchTask = true
-				}
-				if t == "pipelines" {
-					fetchPipeline = true
-				}
-			}
-		}
+		c.Resources[r.Name] = Resource{}
+
 		m, err := fetcher.FetchContractsFromRepository(r, client)
 		if err != nil {
 			return c, err
@@ -45,103 +33,29 @@ func FetchFromExternals(e config.External, client *api.RESTClient) (Catalog, err
 			}
 		}
 
-		for version, contract := range m {
-			if fetchTask {
-				if contract.Catalog.Resources != nil {
-					for _, task := range contract.Catalog.Resources.Tasks {
-						if _, ok := c.Tasks[task.Name]; !ok {
-							// task doesn't exists yet, creating it
-							c.Tasks[task.Name] = Task{
-								Versions: map[string]VersionnedTask{},
-							}
-						}
-						if _, ok := c.Tasks[task.Name].Versions[version]; ok {
-							//  name/version confict
-							return c, fmt.Errorf("Task %s has a version conflict (%s)", task.Name, r.URL)
-						}
-						downloadURL := task.Filename
-						if !strings.HasPrefix(task.Filename, "https://") {
-							downloadURL = fmt.Sprintf("%s/releases/download/%s/%s", r.URL, version, task.Filename)
-						}
-						c.Tasks[task.Name].Versions[version] = VersionnedTask{
-							DownloadURL: downloadURL,
-							// Bundle:      task.Bundle, // FIXME: add bundle support
-						}
-					}
-				}
-			}
-			if fetchPipeline {
-				if contract.Catalog.Resources != nil {
-					for _, pipeline := range contract.Catalog.Resources.Pipelines {
-						if _, ok := c.Pipelines[pipeline.Name]; !ok {
-							// pipeline doesn't exists yet, creating it
-							c.Pipelines[pipeline.Name] = Pipeline{
-								Versions: map[string]VersionnedPipeline{},
-							}
-						}
-						if _, ok := c.Pipelines[pipeline.Name].Versions[version]; ok {
-							// name/version confict
-							return c, fmt.Errorf("Pipeline %s has a version conflict (%s)", pipeline.Name, r.URL)
-						}
-						downloadURL := pipeline.Filename
-						if !strings.HasPrefix(pipeline.Filename, "https://") {
-							downloadURL = fmt.Sprintf("%s/releases/download/%s/%s", r.URL, version, pipeline.Filename)
-						}
-						c.Pipelines[pipeline.Name].Versions[version] = VersionnedPipeline{
-							DownloadURL: downloadURL,
-							// Bundle:      pipeline.Bundle, // FIXME: add bundle support
-						}
-					}
-				}
-			}
+		for version, _ := range m {
+			resourcesDownloaldURI := fmt.Sprintf("%s/releases/download/%s/%s", r.URL, version, "resources.tar.gz")
+			c.Resources[r.Name][version] = resourcesDownloaldURI
 		}
 	}
 	return c, nil
 }
 
 func GenerateFilesystem(path string, c Catalog) error {
-	if err := generateTasksFilesystem(filepath.Join(path, "tasks"), c.Tasks); err != nil {
-		return fmt.Errorf("Failed to create the tasks filesystem: %w", err)
-	}
-	if err := generatePipelinesFilesystem(filepath.Join(path, "pipelines"), c.Pipelines); err != nil {
-		return fmt.Errorf("Failed to create the tasks filesystem: %w", err)
-	}
-	return nil
-}
-
-func generateTasksFilesystem(path string, tasks map[string]Task) error {
-	for name, t := range tasks {
-		for version, task := range t.Versions {
-			taskfolder := filepath.Join(path, name, version)
-			if err := os.MkdirAll(taskfolder, os.ModePerm); err != nil {
-				return err
-			}
-			taskfile := filepath.Join(taskfolder, fmt.Sprintf("%s.yaml", name))
-			if err := fetchAndWrite(taskfile, task.DownloadURL); err != nil {
-				return fmt.Errorf("Couldn't fetch %s in %s: %w", task.DownloadURL, taskfile, err)
+	for name, resource := range c.Resources {
+		fmt.Fprintf(os.Stderr, "# Fetching resource %s\n", name)
+		for version, uri := range resource {
+			fmt.Fprintf(os.Stderr, "## Fetching version %s\n", version)
+			if err := fetchAndExtract(path, uri, version); err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to fetch resource %s: %v, skipping\n", uri, err)
+				continue
 			}
 		}
 	}
 	return nil
 }
 
-func generatePipelinesFilesystem(path string, pipelines map[string]Pipeline) error {
-	for name, t := range pipelines {
-		for version, pipeline := range t.Versions {
-			pipelinefolder := filepath.Join(path, name, version)
-			if err := os.MkdirAll(filepath.Join(path, name, version), os.ModePerm); err != nil {
-				return err
-			}
-			pipelinefile := filepath.Join(pipelinefolder, fmt.Sprintf("%s.yaml", name))
-			if err := fetchAndWrite(pipelinefile, pipeline.DownloadURL); err != nil {
-				return fmt.Errorf("Couldn't fetch %s in %s: %w", pipeline.DownloadURL, pipelinefile, err)
-			}
-		}
-	}
-	return nil
-}
-
-func fetchAndWrite(file, url string) error {
+func fetchAndExtract(path, url, version string) error {
 	resp, err := http.Get(url)
 	if err != nil {
 		return err
@@ -149,40 +63,72 @@ func fetchAndWrite(file, url string) error {
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("Status error: %v", resp.StatusCode)
 	}
-	w, err := os.Create(file)
-	if err != nil {
-		return err
-	}
-	defer w.Close()
-
-	_, err = io.Copy(w, resp.Body)
-	if err != nil {
-		return err
-	}
-	return nil
+	return untar(path, version, resp.Body)
 }
 
-// Catalog is a struct that represent a "file-based" catalog
-// file-based catalog
+func untar(dst, version string, r io.Reader) error {
+	gzr, err := gzip.NewReader(r)
+	if err != nil {
+		return err
+	}
+	defer gzr.Close()
+
+	tr := tar.NewReader(gzr)
+
+	for {
+		header, err := tr.Next()
+		switch {
+		// if no more files are found return
+		case err == io.EOF:
+			return nil
+		// return any other error
+		case err != nil:
+			return err
+		// if the header is nil, just skip it (not sure how this happens)
+		case header == nil:
+			continue
+		}
+
+		// the target location where the dir/file should be created
+		filename := filepath.Base(header.Name)
+		targetFolder := filepath.Join(dst, filepath.Dir(header.Name), version)
+		target := filepath.Join(targetFolder, filename)
+
+		if err := os.MkdirAll(targetFolder, os.ModePerm); err != nil {
+			return err
+		}
+		// the following switch could also be done using fi.Mode(), not sure if there
+		// a benefit of using one vs. the other.
+		// fi := header.FileInfo()
+
+		// check the file type
+		switch header.Typeflag {
+		// if its a dir and it doesn't exist create it
+		case tar.TypeDir:
+			if _, err := os.Stat(target); err != nil {
+				if err := os.MkdirAll(target, 0755); err != nil {
+					return err
+				}
+			}
+		// if it's a file create it
+		case tar.TypeReg:
+			f, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
+			if err != nil {
+				return err
+			}
+			// copy over contents
+			if _, err := io.Copy(f, tr); err != nil {
+				return err
+			}
+			// manually close here after each file operation; defering would cause each file close
+			// to wait until all operations have completed.
+			f.Close()
+		}
+	}
+}
+
 type Catalog struct {
-	Tasks     map[string]Task
-	Pipelines map[string]Pipeline
+	Resources map[string]Resource
 }
 
-type Task struct {
-	Versions map[string]VersionnedTask
-}
-
-type VersionnedTask struct {
-	DownloadURL string
-	Bundle      string
-}
-
-type Pipeline struct {
-	Versions map[string]VersionnedPipeline
-}
-
-type VersionnedPipeline struct {
-	DownloadURL string
-	Bundle      string
-}
+type Resource map[string]string

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -43,7 +43,7 @@ func TestFetchFromExternal(t *testing.T) {
 			Types: []string{"tasks"},
 		}},
 	}
-	c, err := catalog.FetchFromExternal(e, client)
+	c, err := catalog.FetchFromExternals(e, client)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cmd/generate.go
+++ b/internal/cmd/generate.go
@@ -83,11 +83,11 @@ func (v *GenerateCmd) Run(cfg *config.Config) error {
 	return catalog.GenerateFilesystem(v.target, c)
 }
 
-// NewGenerateCmd instantiates the "generate" subcommand.
-func NewGenerateCmd() runner.SubCommand {
+// NewGenerateCatalogCmd instantiates the "generate" subcommand.
+func NewGenerateCatalogCmd() runner.SubCommand {
 	v := &GenerateCmd{
 		cmd: &cobra.Command{
-			Use:          "generate",
+			Use:          "generate-catalog",
 			Args:         cobra.ExactArgs(1),
 			Long:         generateLongDescription,
 			Short:        "Verifies the resource file signature",

--- a/internal/cmd/generate.go
+++ b/internal/cmd/generate.go
@@ -75,7 +75,7 @@ func (v *GenerateCmd) Run(cfg *config.Config) error {
 	if err != nil {
 		return err
 	}
-	c, err := catalog.FetchFromExternal(e, ghclient)
+	c, err := catalog.FetchFromExternals(e, ghclient)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/release.go
+++ b/internal/cmd/release.go
@@ -3,7 +3,9 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/openshift-pipelines/tektoncd-catalog/internal/config"
@@ -18,8 +20,8 @@ import (
 type ReleaseCmd struct {
 	cmd     *cobra.Command // cobra command definition
 	version string         // release version
-	files   []string       // tekton resource files
-	output  string         // output file, where the contract will be written
+	paths   []string       // tekton resource paths
+	output  string         // output path, where the contract and tarball will be written
 }
 
 var _ runner.SubCommand = &ReleaseCmd{}
@@ -51,25 +53,6 @@ func (r *ReleaseCmd) Cmd() *cobra.Command {
 	return r.cmd
 }
 
-// gatherGlogPatternFromArgs creates a set of glob patterns based on the final command line
-// arguments (args), when the slice is empty it assumes the current working directory.
-func (*ReleaseCmd) gatherGlogPatternFromArgs(args []string) ([]string, error) {
-	patterns := []string{}
-
-	if len(args) == 0 {
-		wd, err := os.Getwd()
-		if err != nil {
-			return nil, err
-		}
-		patterns = append(patterns, wd)
-		fmt.Printf("# Using current directory: %q\n", wd)
-	} else {
-		patterns = append(patterns, args...)
-	}
-
-	return patterns, nil
-}
-
 // Complete creates the "release" scope by finding all Tekton resource files using the cli
 // args glob pattern(s).
 func (r *ReleaseCmd) Complete(_ *config.Config, args []string) error {
@@ -77,32 +60,16 @@ func (r *ReleaseCmd) Complete(_ *config.Config, args []string) error {
 	if r.output == "" {
 		return fmt.Errorf("--output flag is not informed")
 	}
-
-	// putting together a slice of glob patterns to search tekton files
-	patterns, err := r.gatherGlogPatternFromArgs(args)
-	if err != nil {
-		return err
-	}
-
-	// going through the pattern slice collected before to select the tekton resource files
-	// to be part of the current release, in other words, release scope
-	fmt.Printf("# Scan Tekton resources on: %s\n", strings.Join(patterns, ", "))
-	for _, pattern := range patterns {
-		files, err := resource.Scanner(pattern)
-		if err != nil {
-			return err
-		}
-		r.files = append(r.files, files...)
-	}
+	r.paths = args
 	return nil
 }
 
 // Validate assert the release scope is not empty.
 func (r *ReleaseCmd) Validate() error {
-	if len(r.files) == 0 {
-		return fmt.Errorf("no tekton resource files have been found")
+	if len(r.paths) == 0 {
+		return fmt.Errorf("no tekton resource paths have been found")
 	}
-	fmt.Printf("# Found %d files to inspect!\n", len(r.files))
+	fmt.Printf("# Found %d path to inspect!\n", len(r.paths))
 	return nil
 }
 
@@ -110,20 +77,45 @@ func (r *ReleaseCmd) Validate() error {
 // on the location informed by the "--output" flag.
 func (r *ReleaseCmd) Run(_ *config.Config) error {
 	c := contract.NewContractEmpty()
+	// going through the pattern slice collected before to select the tekton resource files
+	// to be part of the current release, in other words, release scope
+	fmt.Printf("# Scan Tekton resources on: %s\n", strings.Join(r.paths, ", "))
+	for _, p := range r.paths {
+		files, err := resource.Scanner(p)
+		if err != nil {
+			return err
+		}
 
-	fmt.Printf("# Generating contract for release %q...\n", r.version)
-	for _, f := range r.files {
-		fmt.Printf("# Loading resource file: %q\n", f)
-		if err := c.AddResourceFile(f, r.version); err != nil {
-			if errors.Is(err, contract.ErrTektonResourceUnsupported) {
+		for _, f := range files {
+			fmt.Fprintf(os.Stderr, "# Loading resource file: %q\n", f)
+			taskname := filepath.Base(filepath.Dir(f))
+			if filepath.Base(f) == "README.md" {
+				// This is the README, copy it to output
+				if err := os.MkdirAll(filepath.Join(r.output, taskname), os.ModePerm); err != nil {
+					return err
+				}
+				if err := copyFile(f, filepath.Join(r.output, taskname, "README.md")); err != nil {
+					return err
+				}
+				continue
+			}
+			if err := c.AddResourceFile(f, r.version); err != nil {
+				if errors.Is(err, contract.ErrTektonResourceUnsupported) {
+					return err
+				}
+				fmt.Printf("# WARNING: Skipping file %q!\n", f)
+			}
+
+			// Copy it to output
+			if err := copyFile(f, filepath.Join(r.output, taskname, filepath.Base(f))); err != nil {
 				return err
 			}
-			fmt.Printf("# WARNING: Skipping file %q!\n", f)
 		}
 	}
 
-	fmt.Printf("# Saving release contract at %q\n", r.output)
-	return c.SaveAs(r.output)
+	catalogPath := filepath.Join(r.output, "catalog.yaml")
+	fmt.Printf("# Saving release contract at %q\n", catalogPath)
+	return c.SaveAs(catalogPath)
 }
 
 // NewReleaseCmd instantiates the NewReleaseCmd subcommand and flags.
@@ -141,11 +133,41 @@ func NewReleaseCmd() runner.SubCommand {
 	f := r.cmd.PersistentFlags()
 
 	f.StringVar(&r.version, "version", "", "release version")
-	f.StringVar(&r.output, "output", contract.Filename, "path to the contract file")
+	f.StringVar(&r.output, "output", contract.Filename, "path to the release files (to attach to a given release)")
 
 	if err := r.cmd.MarkPersistentFlagRequired("version"); err != nil {
 		panic(err)
 	}
 
 	return r
+}
+
+func copyFile(src, dst string) error {
+	// Open the source file for reading
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer srcFile.Close()
+
+	// Create the destination file
+	dstFile, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer dstFile.Close()
+
+	// Copy the contents of the source file to the destination file
+	_, err = io.Copy(dstFile, srcFile)
+	if err != nil {
+		return err
+	}
+
+	// Flush the destination file to ensure all data is written
+	err = dstFile.Sync()
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/internal/cmd/release.go
+++ b/internal/cmd/release.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"archive/tar"
+	"compress/gzip"
 	"errors"
 	"fmt"
 	"io"
@@ -69,7 +71,7 @@ func (r *ReleaseCmd) Validate() error {
 	if len(r.paths) == 0 {
 		return fmt.Errorf("no tekton resource paths have been found")
 	}
-	fmt.Printf("# Found %d path to inspect!\n", len(r.paths))
+	fmt.Fprintf(os.Stderr, "# Found %d path to inspect!\n", len(r.paths))
 	return nil
 }
 
@@ -79,7 +81,7 @@ func (r *ReleaseCmd) Run(_ *config.Config) error {
 	c := contract.NewContractEmpty()
 	// going through the pattern slice collected before to select the tekton resource files
 	// to be part of the current release, in other words, release scope
-	fmt.Printf("# Scan Tekton resources on: %s\n", strings.Join(r.paths, ", "))
+	fmt.Fprintf(os.Stderr, "# Scan Tekton resources on: %s\n", strings.Join(r.paths, ", "))
 	for _, p := range r.paths {
 		files, err := resource.Scanner(p)
 		if err != nil {
@@ -89,15 +91,13 @@ func (r *ReleaseCmd) Run(_ *config.Config) error {
 		for _, f := range files {
 			fmt.Fprintf(os.Stderr, "# Loading resource file: %q\n", f)
 			taskname := filepath.Base(filepath.Dir(f))
-			if filepath.Base(f) == "README.md" {
-				// This is the README, copy it to output
-				if err := os.MkdirAll(filepath.Join(r.output, taskname), os.ModePerm); err != nil {
-					return err
-				}
-				if err := copyFile(f, filepath.Join(r.output, taskname, "README.md")); err != nil {
-					return err
-				}
-				continue
+			resourceType, err := resource.GetResourceType(f)
+			if err != nil {
+				return err
+			}
+			resourceFolder := filepath.Join(r.output, strings.ToLower(resourceType), taskname)
+			if err := os.MkdirAll(resourceFolder, os.ModePerm); err != nil {
+				return err
 			}
 			if err := c.AddResourceFile(f, r.version); err != nil {
 				if errors.Is(err, contract.ErrTektonResourceUnsupported) {
@@ -105,17 +105,112 @@ func (r *ReleaseCmd) Run(_ *config.Config) error {
 				}
 				fmt.Printf("# WARNING: Skipping file %q!\n", f)
 			}
-
 			// Copy it to output
-			if err := copyFile(f, filepath.Join(r.output, taskname, filepath.Base(f))); err != nil {
+			if err := copyFile(f, filepath.Join(resourceFolder, filepath.Base(f))); err != nil {
 				return err
+			}
+			readmeFile := filepath.Join(filepath.Dir(f), "README.md")
+			if _, err := os.Stat(readmeFile); err == nil {
+				// This is the README, copy it to output
+				if err := copyFile(f, filepath.Join(resourceFolder, "README.md")); err != nil {
+					return err
+				}
+				continue
 			}
 		}
 	}
 
 	catalogPath := filepath.Join(r.output, "catalog.yaml")
-	fmt.Printf("# Saving release contract at %q\n", catalogPath)
-	return c.SaveAs(catalogPath)
+	fmt.Fprintf(os.Stderr, "# Saving release contract at %q\n", catalogPath)
+	if err := c.SaveAs(catalogPath); err != nil {
+		return err
+	}
+
+	// Create a tarball (without catalog.yaml
+	tarball := filepath.Join(r.output, "resources.tar.gz")
+	fmt.Fprintf(os.Stderr, "# Creating tarball at %q\n", tarball)
+	if err := createTektonResourceArchive(tarball, r.output); err != nil {
+		return err
+	}
+	return nil
+}
+
+func createTektonResourceArchive(archiveFile, output string) error {
+	// Create output file
+	out, err := os.Create(archiveFile)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	// Create the archive
+	return createArchive(output, out)
+}
+func createArchive(output string, buf io.Writer) error {
+	// Create new Writers for gzip and tar
+	// These writers are chained. Writing to the tar writer will
+	// write to the gzip writer which in turn will write to
+	// the "buf" writer
+	gw := gzip.NewWriter(buf)
+	defer gw.Close()
+	tw := tar.NewWriter(gw)
+	defer tw.Close()
+
+	// Iterate over files and add them to the tar archive
+	return filepath.Walk(output, func(file string, fi os.FileInfo, err error) error {
+		// return on any error
+		if err != nil {
+			return err
+		}
+		if filepath.Base(file) == "catalog.yaml" || filepath.Base(file) == "resources.tar.gz" {
+			return nil
+		}
+		if fi.IsDir() || !fi.Mode().IsRegular() {
+			return nil
+		}
+		return addToArchive(tw, file, output)
+	})
+}
+
+func addToArchive(tw *tar.Writer, filename string, output string) error {
+	// Open the file which will be written into the archive
+	file, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	// Get FileInfo about our file providing file size, mode, etc.
+	info, err := file.Stat()
+	if err != nil {
+		return err
+	}
+
+	// Create a tar Header from the FileInfo data
+	header, err := tar.FileInfoHeader(info, info.Name())
+	if err != nil {
+		return err
+	}
+
+	// Use full path as name (FileInfoHeader only takes the basename)
+	// If we don't do this the directory strucuture would
+	// not be preserved
+	// https://golang.org/src/archive/tar/common.go?#L626
+	header.Name = strings.TrimPrefix(filename, filepath.Base(output)+"/")
+
+	// Write file header to the tar archive
+	err = tw.WriteHeader(header)
+	if err != nil {
+		return err
+	}
+
+	// Copy file content to tar archive
+	_, err = io.Copy(tw, file)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // NewReleaseCmd instantiates the NewReleaseCmd subcommand and flags.

--- a/internal/cmd/release.go
+++ b/internal/cmd/release.go
@@ -95,7 +95,7 @@ func (r *ReleaseCmd) Run(_ *config.Config) error {
 			if err != nil {
 				return err
 			}
-			resourceFolder := filepath.Join(r.output, strings.ToLower(resourceType), taskname)
+			resourceFolder := filepath.Join(r.output, strings.ToLower(resourceType)+"s", taskname)
 			if err := os.MkdirAll(resourceFolder, os.ModePerm); err != nil {
 				return err
 			}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -20,7 +20,7 @@ func NewRootCmd(stream *tkncli.Stream) *cobra.Command {
 	rootCmd.AddCommand(runner.NewRunner(cfg, NewProbeCmd()).Cmd())
 	rootCmd.AddCommand(runner.NewRunner(cfg, NewRenderCmd()).Cmd())
 	rootCmd.AddCommand(runner.NewRunner(cfg, NewVerifyCmd()).Cmd())
-	rootCmd.AddCommand(runner.NewRunner(cfg, NewGenerateCmd()).Cmd())
+	rootCmd.AddCommand(runner.NewRunner(cfg, NewGenerateCatalogCmd()).Cmd())
 	rootCmd.AddCommand(runner.NewRunner(cfg, NewReleaseCmd()).Cmd())
 	rootCmd.AddCommand(runner.NewRunner(cfg, NewSignCmd()).Cmd())
 

--- a/internal/cmd/testdata/go-crane-image/README.md
+++ b/internal/cmd/testdata/go-crane-image/README.md
@@ -1,0 +1,3 @@
+# go-crane-image
+
+Build an oci using go and crane.

--- a/internal/cmd/testdata/go-crane-image/go-crane-image.yaml
+++ b/internal/cmd/testdata/go-crane-image/go-crane-image.yaml
@@ -1,0 +1,151 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: go-crane-image
+  labels:
+    app.kubernetes.io/version: "0.2.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.40.0"
+    tekton.dev/categories: language
+    tekton.dev/tags: go
+    tekton.dev/displayName: "go crane image"
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
+spec:
+  description: >-
+    The go-crane-image Task will build a container image based of off a go
+    project to be compiled, using crane.
+  workspaces:
+  - name: source
+    description: The go source to build
+  - name: dockerconfig
+    description: Includes a docker `config.json` or `.dockerconfigjson`
+    optional: true
+  params:
+  - name: app
+    description: >-
+      The name of the "application" to build. This will have an impact on the binary
+      and possibly the image reference
+  - name: package
+    description: >-
+      The package to build. It needs to be a package `main` that compiles into a binary.
+      The default value is `.`, usual value can be `./cmd/{name}`
+    default: .
+  - name: image
+    description: >-
+      The image specific options such as prefix, labels, env, …
+    type: object
+    properties:
+      base: {type: string}
+      labels: {type: string}
+      envs: {type: string}
+      push: {type: string}
+      prefix: {type: string}
+      tag: {type: string}
+    default:
+      base: ""
+      labels: ""
+      envs: ""
+      push: "true"
+      tag: "latest"
+  - name: go
+    description: >-
+      Golang options, such as flags, version, …
+    type: object
+    properties:
+      version: {type: string}
+      GOFLAGS: {type: string}
+      GOOS: {type: string}
+      GOARCH: {type: string}
+      CGO_ENABLED: {type: string}
+    default:
+      version: "1.18"
+      GOFLAGS: "-v"
+      GOOS: ""
+      GOARCH: ""
+      CGO_ENABLED: "0"
+  results:
+    - name: IMAGE_DIGEST
+      description: Digest of the image just built.
+    - name: IMAGE_URL
+      description: URL of the image just built.
+  steps:
+  - name: build-go
+    image: docker.io/library/golang:$(params.go.version)
+    workingDir: $(workspaces.source.path)
+    script: |
+      #!/usr/bin/env bash
+      set -e
+      go env
+      go build -o $(params.app) $(params.package)
+    env:
+    - name: GOFLAGS
+      value: "$(params.go.GOFLAGS)"
+    - name: GOOS
+      value: "$(params.go.GOOS)"
+    - name: GOARCH
+      value: "$(params.go.GOARCH)"
+    - name: CGO_ENABLED
+      value: "$(params.go.CGO_ENABLED)"
+  - name: publish-image
+    image: ghcr.io/shortbrain/golang-tasks/crane:main
+    workingDir: $(workspaces.source.path)
+    script: |
+      #!/usr/bin/env bash
+      set -e
+
+      if [[ "$(params.image.push)" == "false" ]]; then
+        echo "Not doing anything as push is disabled"
+        echo -n "" > $(resutls.IMAGE_DIGEST.path)
+        echo -n "" > $(resutls.IMAGE_URL.path)
+        exit 0
+      fi
+
+      # Prepare the layer to add
+      mkdir output
+      cp $(params.app) ./output
+      # FIXME: extra things to copy ?
+      
+      if [[ "$(workspaces.dockerconfig.bound)" == "true" ]]; then
+        # if config.json exists at workspace root, we use that
+        if test -f "$(workspaces.dockerconfig.path)/config.json"; then
+          export DOCKER_CONFIG="$(workspaces.dockerconfig.path)"
+        # else we look for .dockerconfigjson at the root
+        elif test -f "$(workspaces.dockerconfig.path)/.dockerconfigjson"; then
+          cp "$(workspaces.dockerconfig.path)/.dockerconfigjson" "$HOME/.docker/config.json"
+          export DOCKER_CONFIG="$HOME/.docker"
+        # need to error out if neither files are present
+        else
+          echo "neither 'config.json' nor '.dockerconfigjson' found at workspace root"
+          exit 1
+        fi
+      fi
+
+      APPEND_FLAGS="--new_tag $(params.image.prefix)/$(params.app):$(params.image.tag)"
+      if [[ -n "$(params.image.base)" ]]; then
+        APPEND_FLAGS="--base $(params.image.base) ${APPEND_FLAGS}"
+      fi
+
+      MUTATE_FLAGS="--entrypoint=/$(params.app) --tag $(params.image.prefix)/$(params.app):$(params.image.tag)"
+      # envs
+      while IFS=';' read -ra ENVS; do
+      for ENV in "${ENVS[@]}"; do
+        MUTATE_FLAGS="${MUTATE_FLAGS} --env ${ENV}"
+      done
+      done <<< "$(params.image.envs)"
+
+      # labels
+      while IFS=';' read -ra LABELS; do
+      for LABEL in "${LABELS[@]}"; do
+        MUTATE_FLAGS="${MUTATE_FLAGS} --label ${LABEL}"
+      done
+      done <<< "$(params.image.labels)"
+
+      crane mutate $( \
+        crane append ${APPEND_FLAGS} \
+          --new_layer <(cd ./output && tar -f - -c .) \
+        ) \
+        ${MUTATE_FLAGS} > crane_output
+      CRANE_OUTPUT=$(cat crane_output)
+      echo -n ${CRANE_OUTPUT#*@} > $(results.IMAGE_DIGEST.path)
+      echo -n ${CRANE_OUTPUT} > $(results.IMAGE_URL.path)
+      # echo -n ${CRANE_OUTPUT%@*} > $(results.IMAGE_URL.path)

--- a/internal/cmd/testdata/go-crane-image/tests/run.yaml
+++ b/internal/cmd/testdata/go-crane-image/tests/run.yaml
@@ -1,0 +1,65 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: go-crane-image-source-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: go-crane-image-pipeline
+spec:
+  workspaces:
+    - name: shared-workspace
+  tasks:
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+      params:
+        - name: url
+          value: https://github.com/chmouel/go-rest-api-test
+        - name: subdirectory
+          value: ""
+        - name: deleteExisting
+          value: "true"
+    - name: run-build
+      taskRef:
+        name: go-crane-image
+      runAfter:
+        - fetch-repository
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+      params:
+      - name: app
+        value: go-rest-api
+      - name: go
+        value:
+          CGO_ENABLED: "0"
+      - name: image
+        value:
+          base: docker.io/library/alpine
+          prefix: registry.local:5000/go-rest-api-test
+          labels: foo=bar;bar=baz
+          envs: FOO=bar;BAR=baz
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: go-crane-image-test-run
+spec:
+  pipelineRef:
+    name: go-crane-image-pipeline
+  workspaces:
+    - name: shared-workspace
+      persistentvolumeclaim:
+        claimName: go-crane-image-source-pvc

--- a/internal/cmd/testdata/go-ko-image/README.md
+++ b/internal/cmd/testdata/go-ko-image/README.md
@@ -1,0 +1,3 @@
+# go-ko-image
+
+Build an oci image using go and ko.

--- a/internal/cmd/testdata/go-ko-image/go-ko-image.yaml
+++ b/internal/cmd/testdata/go-ko-image/go-ko-image.yaml
@@ -1,0 +1,178 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: go-ko-image
+  labels:
+    app.kubernetes.io/version: "0.2.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.40.0"
+    tekton.dev/categories: language
+    tekton.dev/tags: go
+    tekton.dev/displayName: "go ko image"
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
+spec:
+  description: >-
+    The go-koimage Task will build a container image based of off a go
+    project using ko.
+  workspaces:
+  - name: source
+    description: The go source to build
+  - name: dockerconfig
+    description: Includes a docker `config.json` or `.dockerconfigjson`
+    optional: true
+  params:
+  - name: app
+    description: >-
+      The name of the "application" to build. This will have an impact on the binary
+      and possibly the image reference
+  - name: package
+    description: >-
+      The package to build. It needs to be a package `main` that compiles into a binary.
+      The default value is `.`, usual value can be `./cmd/{name}`
+    default: .
+  - name: flags
+    description: >-
+      ko extra flags to pass to the ko command
+    default: "--sbom none"
+  - name: image
+    description: >-
+      The image specific options such as prefix, labels, env, …
+    type: object
+    properties:
+      base: {type: string}
+      labels: {type: string}
+      envs: {type: string}
+      push: {type: string}
+      prefix: {type: string}
+      tag: {type: string}
+    default:
+      base: ""
+      labels: ""
+      envs: ""
+      push: "true"
+      tag: "latest"
+  - name: go
+    description: >-
+      Golang options, such as flags, version, …
+    type: object
+    properties:
+      # FIXME: support go version
+      # version: {type: string}
+      GOFLAGS: {type: string}
+      GOOS: {type: string}
+      GOARCH: {type: string}
+      CGO_ENABLED: {type: string}
+    default:
+      # version: "1.18"
+      GOFLAGS: "-v"
+      GOOS: ""
+      GOARCH: ""
+      CGO_ENABLED: "0"
+  results:
+    - name: IMAGE_DIGEST
+      description: Digest of the image just built.
+    - name: IMAGE_URL
+      description: URL of the image just built.
+  steps:
+  - name: build-and-publish
+    image: ghcr.io/ko-build/ko:latest
+    workingDir: $(workspaces.source.path)
+    script: |
+      #!/usr/bin/env bash
+      set -e
+
+      if [[ "$(workspaces.dockerconfig.bound)" == "true" ]]; then
+        # if config.json exists at workspace root, we use that
+        if test -f "$(workspaces.dockerconfig.path)/config.json"; then
+          export DOCKER_CONFIG="$(workspaces.dockerconfig.path)"
+        # else we look for .dockerconfigjson at the root
+        elif test -f "$(workspaces.dockerconfig.path)/.dockerconfigjson"; then
+          cp "$(workspaces.dockerconfig.path)/.dockerconfigjson" "$HOME/.docker/config.json"
+          export DOCKER_CONFIG="$HOME/.docker"
+        # need to error out if neither files are present
+        else
+          echo "neither 'config.json' nor '.dockerconfigjson' found at workspace root"
+          exit 1
+        fi
+      fi
+
+      KO_FLAGS="$(params.flags) --tags $(params.image.tag)"
+      if [[ "$(params.image.push)" == "false" ]]; then
+        KO_FLAGS="${KO_FLAGS} --push=false"
+      fi
+
+      # labels
+      while IFS=';' read -ra LABELS; do
+      for LABEL in "${LABELS[@]}"; do
+        KO_FLAGS="${KO_FLAGS} --image-label ${LABEL}"
+      done
+      done <<< "$(params.image.labels)"
+
+      go env
+
+      echo "defaultBaseImage: $(params.image.base)" > .ko.yaml
+
+      set -x
+      ko build --base-import-paths ${KO_FLAGS} $(params.package) > $(results.IMAGE_URL.path)
+      set +x
+      
+      KO_OUTPUT=$(results.IMAGE_URL.path)
+      echo -n ${CRANE_OUTPUT#*@} > $(results.IMAGE_DIGEST.path)
+    env:
+    - name: GOFLAGS
+      value: "$(params.go.GOFLAGS)"
+    - name: GOOS
+      value: "$(params.go.GOOS)"
+    - name: GOARCH
+      value: "$(params.go.GOARCH)"
+    - name: CGO_ENABLED
+      value: "$(params.go.CGO_ENABLED)"
+    - name: KO_DOCKER_REPO
+      value: $(params.image.prefix)
+  - name: add-metadata
+    image: ghcr.io/shortbrain/golang-tasks/crane:main
+    workingDir: $(workspaces.source.path)
+    script: |
+      #!/usr/bin/env bash
+      set -e
+
+      if [[ "$(params.image.push)" == "false" ]]; then
+        echo "Not doing anything as push is disabled"
+        echo -n "" > $(resutls.IMAGE_DIGEST.path)
+        echo -n "" > $(resutls.IMAGE_URL.path)
+        exit 0
+      fi
+      
+      if [[ "$(workspaces.dockerconfig.bound)" == "true" ]]; then
+        # if config.json exists at workspace root, we use that
+        if test -f "$(workspaces.dockerconfig.path)/config.json"; then
+          export DOCKER_CONFIG="$(workspaces.dockerconfig.path)"
+        # else we look for .dockerconfigjson at the root
+        elif test -f "$(workspaces.dockerconfig.path)/.dockerconfigjson"; then
+          cp "$(workspaces.dockerconfig.path)/.dockerconfigjson" "$HOME/.docker/config.json"
+          export DOCKER_CONFIG="$HOME/.docker"
+        # need to error out if neither files are present
+        else
+          echo "neither 'config.json' nor '.dockerconfigjson' found at workspace root"
+          exit 1
+        fi
+      fi
+
+      if [[ -z "$(params.image.envs)" ]]; then
+        echo "Not doing anything as there is no envs specified"
+      fi
+      
+      MUTATE_FLAGS=" --tag $(params.image.prefix)/$(params.app)"
+      # envs
+      while IFS=';' read -ra ENVS; do
+      for ENV in "${ENVS[@]}"; do
+        MUTATE_FLAGS="${MUTATE_FLAGS} --env ${ENV}"
+      done
+      done <<< "$(params.image.envs)"
+      
+      crane mutate $(cat $(results.IMAGE_URL.path)) \
+        ${MUTATE_FLAGS} > crane_output
+      CRANE_OUTPUT=$(cat crane_output)
+      echo -n ${CRANE_OUTPUT#*@} > $(results.IMAGE_DIGEST.path)
+      echo -n ${CRANE_OUTPUT} > $(results.IMAGE_URL.path)
+      # echo -n ${CRANE_OUTPUT%@*} > $(results.IMAGE_URL.path)

--- a/internal/cmd/testdata/go-ko-image/tests/run.yaml
+++ b/internal/cmd/testdata/go-ko-image/tests/run.yaml
@@ -1,0 +1,65 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: go-ko-image-source-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: go-ko-image-pipeline
+spec:
+  workspaces:
+    - name: shared-workspace
+  tasks:
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+      params:
+        - name: url
+          value: https://github.com/chmouel/go-rest-api-test
+        - name: subdirectory
+          value: ""
+        - name: deleteExisting
+          value: "true"
+    - name: run-build
+      taskRef:
+        name: go-ko-image
+      runAfter:
+        - fetch-repository
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+      params:
+      - name: app
+        value: go-rest-api
+      - name: go
+        value:
+          CGO_ENABLED: "0"
+      - name: image
+        value:
+          base: docker.io/library/alpine
+          prefix: registry.local:5000/go-rest-api-test
+          labels: foo=bar;bar=baz
+          envs: FOO=bar;BAR=baz
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: go-ko-image-test-run
+spec:
+  pipelineRef:
+    name: go-ko-image-pipeline
+  workspaces:
+    - name: shared-workspace
+      persistentvolumeclaim:
+        claimName: go-ko-image-source-pvc

--- a/internal/contract/catalog_resources.go
+++ b/internal/contract/catalog_resources.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/openshift-pipelines/tektoncd-catalog/internal/resource"
 )
@@ -69,7 +70,7 @@ func (c *Contract) VerifyResources(ctx context.Context, fn ResourceVerifySignatu
 
 // AddResourceFile adds a resource file on the contract, making sure it's a Tekton resource
 // file and uses the "kind" to guide on which attribute the resource will be appended.
-func (c *Contract) AddResourceFile(resourceFile string, version string) error {
+func (c *Contract) AddResourceFile(resourceFile, version string) error {
 	// parsing the resource as a kubernetes unstructured type to read it's name and kind
 	u, err := resource.ReadAndDecodeResourceFile(resourceFile)
 	if err != nil {
@@ -85,7 +86,7 @@ func (c *Contract) AddResourceFile(resourceFile string, version string) error {
 		return err
 	}
 
-	filename := filepath.Join(filepath.Base(filepath.Dir(resourceFile)), filepath.Base(resourceFile))
+	filename := filepath.Join(strings.ToLower(u.GetKind()), filepath.Base(filepath.Dir(resourceFile)), filepath.Base(resourceFile))
 
 	tr := TektonResource{
 		Name:     u.GetName(),

--- a/internal/contract/catalog_resources.go
+++ b/internal/contract/catalog_resources.go
@@ -86,7 +86,7 @@ func (c *Contract) AddResourceFile(resourceFile, version string) error {
 		return err
 	}
 
-	filename := filepath.Join(strings.ToLower(u.GetKind()), filepath.Base(filepath.Dir(resourceFile)), filepath.Base(resourceFile))
+	filename := filepath.Join(strings.ToLower(u.GetKind())+"s", filepath.Base(filepath.Dir(resourceFile)), filepath.Base(resourceFile))
 
 	tr := TektonResource{
 		Name:     u.GetName(),

--- a/internal/contract/catalog_resources.go
+++ b/internal/contract/catalog_resources.go
@@ -3,6 +3,7 @@ package contract
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 
 	"github.com/openshift-pipelines/tektoncd-catalog/internal/resource"
 )
@@ -84,10 +85,12 @@ func (c *Contract) AddResourceFile(resourceFile string, version string) error {
 		return err
 	}
 
+	filename := filepath.Join(filepath.Base(filepath.Dir(resourceFile)), filepath.Base(resourceFile))
+
 	tr := TektonResource{
 		Name:     u.GetName(),
 		Version:  version,
-		Filename: resourceFile,
+		Filename: filename,
 		Checksum: sha256sum,
 	}
 

--- a/internal/fetcher/fetcher.go
+++ b/internal/fetcher/fetcher.go
@@ -9,14 +9,7 @@ import (
 	"github.com/openshift-pipelines/tektoncd-catalog/internal/fetcher/config"
 )
 
-// TODO: fetch release assets
-//   - fetch yamls
-//   - fetch tests (yamls with kttl)
-//   - fetch bundles, sbom, …
-//
-// TODO: write catalog.yaml in some places (so that we could regenerate it)
-//
-//	(warn if there is conflicts)
+// FetchContractsFromRepository fetches contracts from a repository.
 func FetchContractsFromRepository(r config.Repository, client *api.RESTClient) (map[string]*contract.Contract, error) {
 	m := map[string]*contract.Contract{}
 
@@ -36,7 +29,7 @@ func FetchContractsFromRepository(r config.Repository, client *api.RESTClient) (
 		var contractAsset Asset
 		contractFound := false
 		for _, a := range v.Assets {
-			if a.Name == "catalog.yaml" {
+			if a.Name == "catalog.yaml" || a.Name == "catalog.yml" {
 				contractFound = true
 				contractAsset = a
 				break

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -44,3 +44,11 @@ func ReadAndDecodeResourceFile(resourceFile string) (*unstructured.Unstructured,
 	}
 	return &u, nil
 }
+
+func GetResourceType(resourceFile string) (string, error) {
+	u, err := ReadAndDecodeResourceFile(resourceFile)
+	if err != nil {
+		return "", err
+	}
+	return u.GetKind(), nil
+}

--- a/internal/resource/scanner.go
+++ b/internal/resource/scanner.go
@@ -16,7 +16,6 @@ func Scanner(pattern string) ([]string, error) {
 	if info != nil && info.IsDir() {
 		patterns = append(patterns, path.Join(pattern, "*.yml"))
 		patterns = append(patterns, path.Join(pattern, "*.yaml"))
-		patterns = append(patterns, path.Join(pattern, "README.md"))
 	}
 
 	files := []string{}

--- a/internal/resource/scanner.go
+++ b/internal/resource/scanner.go
@@ -16,6 +16,7 @@ func Scanner(pattern string) ([]string, error) {
 	if info != nil && info.IsDir() {
 		patterns = append(patterns, path.Join(pattern, "*.yml"))
 		patterns = append(patterns, path.Join(pattern, "*.yaml"))
+		patterns = append(patterns, path.Join(pattern, "README.md"))
 	}
 
 	files := []string{}


### PR DESCRIPTION
- Rename `generate` to `generate-catalog`
- `release` creates a tarball per release
- `generate-catalog` extracts "smartly" that tarball
- Update workflow to use `generate-catalog` subcommand