### PR TITLE
.github/workflows: generate the catalogs every 6 hours

### DIFF
--- a/.github/workflows/generate-catalogs.yaml
+++ b/.github/workflows/generate-catalogs.yaml
@@ -5,7 +5,7 @@ name: generate-catalogs
 
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "0 */6 * * *" # every 6 hours
   workflow_dispatch: # allow manual triggering
 
 jobs:


### PR DESCRIPTION
Let's "pull" content to the catalog more often than daily.