### PR TITLE
generate-from: make sure we take the type into account

### DIFF
--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -39,6 +39,9 @@ func FetchFromExternals(e config.External, client *api.RESTClient) (Catalog, err
 
 		for version := range m {
 			resourcesDownloaldURI := fmt.Sprintf("%s/releases/download/%s/%s", r.URL, version, "resources.tar.gz")
+			if strings.HasPrefix(version, "v") {
+				version = strings.TrimPrefix(version, "v")
+			}
 			c.Resources[r.Name][version] = resourcesDownloaldURI
 		}
 	}

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -109,7 +109,7 @@ func TestGenerateFilesystem(t *testing.T) {
 		// 	},
 		// },
 	}
-	err := catalog.GenerateFilesystem(dir.Path(), c)
+	err := catalog.GenerateFilesystem(dir.Path(), c, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cmd/generate-from.go
+++ b/internal/cmd/generate-from.go
@@ -82,7 +82,6 @@ func (v *GenerateFromExternalCmd) Run(cfg *config.Config) error {
 		Repositories: []fc.Repository{{
 			Name:           name,
 			URL:            v.url,
-			Types:          []string{v.resourceType},
 			IgnoreVersions: ignoreVersions,
 		}},
 	}
@@ -91,7 +90,7 @@ func (v *GenerateFromExternalCmd) Run(cfg *config.Config) error {
 		return err
 	}
 
-	return catalog.GenerateFilesystem(v.target, c)
+	return catalog.GenerateFilesystem(v.target, c, v.resourceType)
 }
 
 // NewCatalogGenerateFromExternalCmd instantiates the "generate" subcommand.

--- a/internal/cmd/generate.go
+++ b/internal/cmd/generate.go
@@ -80,7 +80,7 @@ func (v *GenerateCmd) Run(cfg *config.Config) error {
 		return err
 	}
 
-	return catalog.GenerateFilesystem(v.target, c)
+	return catalog.GenerateFilesystem(v.target, c, "")
 }
 
 // NewCatalogGenerateCmd instantiates the "generate" subcommand.


### PR DESCRIPTION
Filter things we pull by the type. Prior to this, the type specified
in the command-line would be ignore.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>
