### PR TITLE
chore: update OCP V GH link

### DIFF
--- a/externals.yaml
+++ b/externals.yaml
@@ -16,7 +16,7 @@ repositories:
   - tasks
   - pipelines
   ignore-versions: [ "v0.1.0" ]
-- url: https://github.com/openshift-cnv/openshift-virtualization-pipelines-tasks
+- url: https://github.com/openshift-virtualization/openshift-virtualization-pipelines-tasks
   types:
   - tasks
   - pipelines


### PR DESCRIPTION
chore: update OCP V GH link
OCP V tasks and pipelines were migrated to
github.com//openshift-virtualization/openshift-virtualization-pipelines-tasks. This PR updates externals.yaml file to point to correct location