### PR TITLE
Do not fail if a type is not present in a release

### DIFF
--- a/.github/workflows/generate-catalogs.yaml
+++ b/.github/workflows/generate-catalogs.yaml
@@ -43,9 +43,9 @@ jobs:
           set -Eeu
 
           mkdir -p stable/tasks stable/pipelines stable/stepactions
-          cp -fRv tasks/* stable/tasks
-          cp -fRv pipelines/* stable/pipelines
-          cp -fRv stepactions/* stable/stepactions
+          cp -fRv tasks/* stable/tasks || true
+          cp -fRv pipelines/* stable/pipelines || true
+          cp -fRv stepactions/* stable/stepactions || true
           catalog-cd catalog generate-from \
                  --name ${{ matrix.name }} \
                  --url ${{ matrix.url }} \

--- a/.github/workflows/generate-experimental-catalogs.yaml
+++ b/.github/workflows/generate-experimental-catalogs.yaml
@@ -55,9 +55,9 @@ jobs:
           path: p
       - name: Copy "partial" catalog ${{ matrix.name }} in publish branch
         run: |
-          cp -fRv experimental/tasks/* p/experimental/tasks
-          cp -fRv experimental/pipelines/* p/experimental/pipelines
-          cp -fRv experimental/stepactions/* p/experimental/stepactions
+          cp -fRv experimental/tasks/* p/experimental/tasks || true
+          cp -fRv experimental/pipelines/* p/experimental/pipelines || true
+          cp -fRv experimental/stepactions/* p/experimental/stepactions || true
       - name: Add ${{ matrix.type }} from ${{ matrix.name }} to publish branch
         working-directory: p
         run: |


### PR DESCRIPTION
For example, old release might not have a `stepaction` type, but we
shouldn't fail the catalog generation because of that.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>
